### PR TITLE
不動産取引価格検索API追加

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { TownPlanningModule } from './modules/town-planning/town-planning.module';
+
+@Module({
+  imports: [TownPlanningModule]
+})
+export class AppModule {}

--- a/src/modules/town-planning/controllers/estate-transaction.controller.ts
+++ b/src/modules/town-planning/controllers/estate-transaction.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { EstateTransactionQueryDto } from '../domain/dto/estate-transaction.dto';
+import { GetEstateTransactionUseCase } from '../use-cases/get-estate-transaction.use-case';
+import { EstateTransactionResponse } from '../domain/types/estate-transaction.type';
+
+@Controller('api/v1/townPlanning/estateTransaction') // URLパスを定義
+export class EstateTransactionController {
+  // ユースケースを注入
+  constructor(
+    private readonly getEstateTransactionUseCase: GetEstateTransactionUseCase
+  ) {}
+
+  @Get('bar') // GETリクエストのエンドポイントを定義
+  async getEstateTransactions(
+    @Query() query: EstateTransactionQueryDto
+  ): Promise<EstateTransactionResponse> {
+    // クエリパラメーターを受け取り、ユースケースを実行
+    return this.getEstateTransactionUseCase.execute(
+      query.year,
+      query.prefectureCode,
+      query.type
+    );
+  }
+}

--- a/src/modules/town-planning/domain/dto/estate-transaction.dto.ts
+++ b/src/modules/town-planning/domain/dto/estate-transaction.dto.ts
@@ -1,0 +1,21 @@
+import { IsIn, IsNumber, Max, Min } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+//　APIリクエストのデータ構造を定義する
+export class EstateTransactionQueryDto {
+  @Transform(({ value }) => parseInt(value, 10))
+  @IsNumber() // 数値であることを確認
+  @Min(2015) // 最小値は2015
+  @Max(2018) // 最大値は2018
+  year: number; // 年度
+
+  @Transform(({ value }) => parseInt(value, 10))
+  @IsNumber() // 数値であることを確認
+  @IsIn([8, 9, 10, 11, 12, 13, 14]) // 関東地方の都道府県コードのみ許可
+  prefectureCode: number; // 都道府県コード
+
+  @Transform(({ value }) => parseInt(value, 10))
+  @IsNumber() // 数値であることを確認
+  @IsIn([1, 2]) // 1または2のみを許可
+  type: number; // 種別（1：住宅地、2：商業地）
+}

--- a/src/modules/town-planning/domain/interfaces/estate-transaction.repository.ts
+++ b/src/modules/town-planning/domain/interfaces/estate-transaction.repository.ts
@@ -1,0 +1,13 @@
+import { EstateTransaction } from '../types/estate-transaction.type';
+
+export interface IEstateTransactionRepository {
+  // 条件に基づいてデータを検索するメソッドを定義
+  findByConditions(
+    year: number,
+    prefectureCode: number,
+    type: number
+  ): Promise<EstateTransaction[]>;
+}
+
+// 依存性注入
+export const ESTATE_TRANSACTION_REPOSITORY = 'ESTATE_TRANSACTION_REPOSITORY';

--- a/src/modules/town-planning/domain/types/estate-transaction.type.ts
+++ b/src/modules/town-planning/domain/types/estate-transaction.type.ts
@@ -1,0 +1,26 @@
+export interface YearlyValue {
+  year: number;
+  value: number;
+}
+
+export interface EstateTransactionResult {
+  prefectureCode: string;
+  prefectureName: string;
+  type: string;
+  years: YearlyValue[];
+}
+
+export interface EstateTransaction {
+  year: number;
+  prefectureCode: number;
+  type: number;
+  data: {
+    result: EstateTransactionResult;
+  };
+}
+
+export interface EstateTransactionResponse {
+  status: 'success' | 'error';
+  data?: EstateTransaction[];
+  message?: string;
+}

--- a/src/modules/town-planning/infrastructure/json/estate-transaction.json.repository.ts
+++ b/src/modules/town-planning/infrastructure/json/estate-transaction.json.repository.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { IEstateTransactionRepository } from '../../domain/interfaces/estate-transaction.repository';
+import * as estateTransactions from '../../../../assets/estate_transactions.json';
+import { EstateTransaction } from '../../domain/types/estate-transaction.type';
+
+@Injectable()
+export class EstateTransactionJsonRepository
+  implements IEstateTransactionRepository
+{
+  async findByConditions(
+    year: number,
+    prefectureCode: number,
+    type: number
+  ): Promise<EstateTransaction[]> {
+    const typedTransaction = estateTransactions as EstateTransaction[];
+    // JSONファイルからデータをフィルタリングする
+    return typedTransaction.filter(
+      (transaction) =>
+        Number(transaction.year) === Number(year) &&
+        Number(transaction.prefectureCode) === Number(prefectureCode) &&
+        Number(transaction.type) === Number(type)
+    );
+  }
+}

--- a/src/modules/town-planning/town-planning.module.ts
+++ b/src/modules/town-planning/town-planning.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { EstateTransactionController } from './controllers/estate-transaction.controller';
+import { GetEstateTransactionUseCase } from './use-cases/get-estate-transaction.use-case';
+import { ESTATE_TRANSACTION_REPOSITORY } from './domain/interfaces/estate-transaction.repository';
+import { EstateTransactionJsonRepository } from './infrastructure/json/estate-transaction.json.repository';
+
+@Module({
+  controllers: [EstateTransactionController],
+  providers: [
+    GetEstateTransactionUseCase,
+    {
+      provide: ESTATE_TRANSACTION_REPOSITORY,
+      useClass: EstateTransactionJsonRepository
+    }
+  ]
+})
+export class TownPlanningModule {}

--- a/src/modules/town-planning/use-cases/get-estate-transaction.use-case.ts
+++ b/src/modules/town-planning/use-cases/get-estate-transaction.use-case.ts
@@ -1,0 +1,34 @@
+import { Injectable, Inject } from '@nestjs/common';
+import {
+  ESTATE_TRANSACTION_REPOSITORY,
+  IEstateTransactionRepository
+} from '../domain/interfaces/estate-transaction.repository';
+import { EstateTransactionResponse } from '../domain/types/estate-transaction.type';
+
+@Injectable()
+export class GetEstateTransactionUseCase {
+  // リポジトリを注入（依存性注入）
+  constructor(
+    @Inject(ESTATE_TRANSACTION_REPOSITORY)
+    private readonly repository: IEstateTransactionRepository
+  ) {}
+
+  async execute(
+    year: number,
+    prefectureCode: number,
+    type: number
+  ): Promise<EstateTransactionResponse> {
+    // リポジトリからデータを取得する
+    const transactions = await this.repository.findByConditions(
+      year,
+      prefectureCode,
+      type
+    );
+
+    // 取得したデータをレスポンスに変換する
+    return {
+      status: 'success',
+      data: transactions
+    };
+  }
+}


### PR DESCRIPTION
## issue番号
<!-- #から始まるもの -->
Closes #

## 変更箇所

- クエリーパラメーターバリデーション追加
- レスポンス型定義追加
- 不動産取引価格検索関数作成
- リポジトリ作成
- リポジトリインターフェース作成
- ユースケース作成
- コントローラー作成
- モジュール作成＆読み込み


## 動作確認方法

### バリデーション
<img width="964" alt="Screenshot 2024-11-19 at 23 43 17" src="https://github.com/user-attachments/assets/4f78b694-7018-4729-8415-961d2358fa49">

### 正常系
<img width="975" alt="Screenshot 2024-11-19 at 23 43 34" src="https://github.com/user-attachments/assets/8c3c167b-29d6-4c78-a367-6bfe311908e7">


---

## このPRでやっていないこと(あれば)


## 関連する他PR(あれば)

### その他
<!-- 参考にしたURLなど -->